### PR TITLE
Add: Support for Gitsigns current_line_blame

### DIFF
--- a/lua/oldschool.lua
+++ b/lua/oldschool.lua
@@ -99,6 +99,7 @@ oldschool.color_groups = function(p)
         GitSignsAdd                           = { fg = p.dark_green, bold = true },
         GitSignsChange                        = { fg = p.yellow, bold = true },
         GitSignsDelete                        = { fg = p.red, bold = true },
+        GitSignsCurrentLineBlame              = { fg = p.light_grey, bold = false },
 
         -- IndentBlankline
         IblIndent                             = { fg = p.dark_grey },


### PR DESCRIPTION
The GitSigns are currently just white, and are not styled correctly. The text should be a bit darker, not full on white. I think p.light_grey works perfectly fine.

<img width="497" height="69" alt="8G3image" src="https://github.com/user-attachments/assets/149a5e74-32fd-43f0-a9d9-3c84d77ac022" />
